### PR TITLE
Set EndpointPublicAccess to model config

### DIFF
--- a/cmd/resource/eks.go
+++ b/cmd/resource/eks.go
@@ -58,7 +58,7 @@ func makeCreateClusterInput(model *Model) *eks.CreateClusterInput {
 		Name: model.Name,
 		ResourcesVpcConfig: &eks.VpcConfigRequest{
 			SubnetIds:             aws.StringSlice(model.ResourcesVpcConfig.SubnetIds),
-			EndpointPublicAccess:  aws.Bool(true),
+			EndpointPublicAccess:  model.ResourcesVpcConfig.EndpointPublicAccess,
 			EndpointPrivateAccess: model.ResourcesVpcConfig.EndpointPrivateAccess,
 		},
 		Logging:          createLogging(model),


### PR DESCRIPTION
*Issue #, if available:*
#5 
*Description of changes:*
Change the cluster to get created with the settings defined by the user, as opposed to "true" and resolved later with a cluster update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
