### PR TITLE
Add GetObject permission to RegisterTypeRole, fix for the open issue #13

### DIFF
--- a/deploy.template.yaml
+++ b/deploy.template.yaml
@@ -131,6 +131,7 @@ Resources:
                 Action:
                   - "cloudformation:*"
                   - "iam:PassRole"
+                  - "s3:GetObject"
                 Resource: "*"
   RegisterTypeFunction:
     Type: "AWS::Lambda::Function"


### PR DESCRIPTION
**This PR should fix the issues faced during the stack creation from the template provided with the quick start solution**

Bugfix for this issue : [#13](https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider/issues/13)

*Description of changes:*
Updated the deploy.template.yaml to add  `s3:GetObject`permissions to the `RegisterTypeRole` resource, required for Resource Provider registration.
